### PR TITLE
QueryInListSerializer should not always auto quote 

### DIFF
--- a/SolrNet/Impl/QuerySerializers/QueryInListSerializer.cs
+++ b/SolrNet/Impl/QuerySerializers/QueryInListSerializer.cs
@@ -31,7 +31,7 @@ namespace SolrNet.Impl.QuerySerializers {
             if (string.IsNullOrEmpty(q.FieldName) || q.List == null || !q.List.Any())
                 return null;
 
-            var array = q.List.Select(x =>"(" + QueryByFieldSerializer.Quote(x) + ")").ToArray();
+            var array = q.List.Select(x =>"(" + (q.Quoted ? QueryByFieldSerializer.Quote(x) : x) + ")").ToArray();
             return "(" + serializer.Serialize(new SolrQueryByField(QueryByFieldSerializer.EscapeSpaces(q.FieldName),string.Join(" OR ",array)){Quoted = false}) + ")";
         }
     }

--- a/SolrNet/SolrQueryInList.cs
+++ b/SolrNet/SolrQueryInList.cs
@@ -32,6 +32,7 @@ namespace SolrNet {
         public SolrQueryInList(string fieldName, IEnumerable<string> list) {
             this.fieldName = fieldName;
             this.list = list;
+            Quoted = true;
         }
 
         /// <summary>
@@ -40,6 +41,11 @@ namespace SolrNet {
         /// <param name="fieldName">Solr field name</param>
         /// <param name="values">Field values to query</param>
         public SolrQueryInList(string fieldName, params string[] values) : this(fieldName, (IEnumerable<string>) values) {}
+
+        /// <summary>
+        /// If true (default), special characters (e.g. '?', '*') in the value are quoted.
+        /// </summary>
+        public bool Quoted { get; set; }
 
         /// <summary>
         /// Field name


### PR DESCRIPTION
QueryInListSerializer was automatically quoting all values which made it impossible to use queries in form: Year: *. Added Quoted property similarly to the one SolrQueryField is using to allow for skipping quoting. It's true by default.
